### PR TITLE
add react-lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tslint": "^5.8.0"
   },
   "dependencies": {
-    "tslint-config-airbnb": "^5.9.2"
+    "tslint-config-airbnb": "^5.9.2",
+    "tslint-react": "^3.6.0"
   }
 }

--- a/tslint-base.json
+++ b/tslint-base.json
@@ -1,6 +1,6 @@
 {
   "defaultSeverity": "error",
-  "extends": "tslint-config-airbnb",
+  "extends": ["tslint-config-airbnb", "tslint-react"],
   "jsRules": {},
   "rules": {
       "array-bracket-spacing": false,
@@ -19,6 +19,8 @@
       "align": false,
       "no-increment-decrement": false,
       "prefer-array-literal": false,
+      "jsx-no-lambda": false,
+      "jsx-no-multiline-js": false,
       "variable-name": [
           true,
           "ban-keywords",

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,13 +84,19 @@ tslint-microsoft-contrib@~5.0.1:
   dependencies:
     tsutils "^2.12.1"
 
+tslint-react@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.6.0.tgz#7f462c95c4a0afaae82507f06517ff02942196a1"
+  dependencies:
+    tsutils "^2.13.1"
+
 tsutils@2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.0.tgz#0160173729b3bf138628dd14a1537e00851d814a"
   dependencies:
     tslib "^1.7.1"
 
-tsutils@^2.12.1, tsutils@^2.24.0, tsutils@^2.27.0:
+tsutils@^2.12.1, tsutils@^2.13.1, tsutils@^2.24.0, tsutils@^2.27.0:
   version "2.27.2"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
   dependencies:


### PR DESCRIPTION
This adds `react-lint` and turns off a few rules. Wanna try to update this incrementally if it makes sense to have these rules.

`jsx-no-lambda` is really to avoid anonymous functions that cause re renders.
All in all this is a good rule, but there are times when this doesn't impact performance.
I don't _think_ it's always necessary.

https://github.com/palantir/tslint-react/issues/96 -- people seem torn

`jsx-no-multiline-js` is solely for cleaner code. Which is also good. We just have this all over the place right now. 🤷‍♀️ 

Thoughts? Could also disable where we see fit.